### PR TITLE
Automatically kick trolls

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,44 @@ The export utilities  perform the needed transformation, so in Blender you just 
 ## Building from source
 
 Building instructions can be found in [`INSTALL.md`](/INSTALL.md)
+
+## Info on experimental anti-troll system
+If activated, a timer is kept for all players. System can be activated in xml config or in the lobby with command:
+\admin troll [0,1]
+
+Timer is increased by the amount of time when
+* a player drives in the wrong way
+* a player moves below a given speed (troll-max-stop-speed)
+
+Timer is not increased when the player is hit or rescued (during animation).
+
+It is decreased (not below 0 obviously) when a player drives in correct direction with at least given speed (troll-min-normal-speed).
+
+If a player's timer exceeds the warning level (troll-warning-time), they get a warning (troll-warn-message). After that the timer is reset.
+If a player got a warning and their timer exceeds the kick level (troll-kick-time), they get kicked.
+Warnings and Kicks are logged.
+
+Config can be controlled in xml file like this:
+
+    <!-- Set values for anti-troll system -->
+    <!-- If true, use anti troll system
+         This can also be controlled with server command:
+         \admin troll [0,1] -->
+    <use-anti-troll-system value="true" />
+    <!-- Warn string to show to player -->
+    <troll-warn-message value="WARNING: You troll, you get kicked !!" />
+    <!-- Warn player that drives backwards or stopps for given time -->
+    <troll-warning-time value="7.0" />
+    <!-- Kick player that drives backwards or stopps for given time -->
+    <troll-kick-time value="10.0" />
+    <!-- Minimum speed in correct direction to decrease wrong-way timer -->
+    <troll-min-normal-speed value="12.0" />
+    <!-- A player going slower than this is considered stopping -->
+    <troll-max-stop-speed value="5.0" />
+
+### Things to note
+* The system can be fooled of course, but it should be a lot harder to troll. Testing would be necessary. However, when I set up a test server, most players coming by just wanted to play normally...
+* The system should not warn or kick weak players who get lost or stuck on obstacles (too quickly). The current configuration values are most probably not yet perfect.
+* Players should probably be informed about the system, because waiting for others (like some pros do when giving weaker players some advice or driving lessons) would be punished, so the system should not be activated in those cases.
+* If a player presses UP-key early, the timer is increased during time punishment at the beginning of the race (1 sec). I don't know how to find out if a player is in that state.
+* **There may still be bugs** (of course)... ;)

--- a/src/main_loop.cpp
+++ b/src/main_loop.cpp
@@ -600,6 +600,22 @@ void MainLoop::run()
                     PROFILER_POP_CPU_MARKER();
                 }
             }
+            else
+            {
+                if (World::getWorld())
+                {
+                    // test if player is driving backward
+                    float frame_duration = num_steps * dt;
+                    LinearWorld *lin_world = dynamic_cast<LinearWorld*>(World::getWorld());
+                    if (lin_world && lin_world->getTicksSinceStart() > 0)
+                    {
+                        for (unsigned int i = 0; i < lin_world->getNumKarts(); i++)
+                        {
+                            lin_world->serverCheckForWrongDirection(i,frame_duration);
+                        }
+                    }
+                }
+            }
             // Some protocols in network will use RequestManager
             if (!m_download_assets)
             {

--- a/src/modes/linear_world.cpp
+++ b/src/modes/linear_world.cpp
@@ -1139,10 +1139,10 @@ void LinearWorld::serverCheckForWrongDirection(unsigned int i, float dt)
     {
         if (!kart->hasFinishedRace() && !kart->getKartAnimation())
         {
-            if (kart->getSpeed() < 5.0)
+            if (kart->getSpeed() < ServerConfig::m_troll_max_stop_speed)
                 // stopping is also trolling
                 ki.m_wrong_way_timer += dt;
-            else if(kart->getSpeed() > 15.0)
+            else if(kart->getSpeed() > ServerConfig::m_troll_min_normal_speed)
             {
                 // racing normally reduces timer
                 ki.m_wrong_way_timer -= dt;

--- a/src/modes/linear_world.cpp
+++ b/src/modes/linear_world.cpp
@@ -1096,6 +1096,75 @@ void LinearWorld::checkForWrongDirection(unsigned int i, float dt)
 }   // checkForWrongDirection
 
 //-----------------------------------------------------------------------------
+/** Checks if a kart is going in the wrong direction.
+ *  This is the online server only version to kick players
+ *  who misbehave.
+ *  \param i Kart id.
+ *  \param dt Time step size.
+ */
+void LinearWorld::serverCheckForWrongDirection(unsigned int i, float dt)
+{
+    KartInfo &ki = m_kart_info[i];
+
+    const AbstractKart *kart=m_karts[i].get();
+    // If the kart can go in more than one directions from the current track
+    // don't do any reverse message handling, since it is likely that there
+    // will be one direction in which it isn't going backwards anyway.
+    int sector = getTrackSector(i)->getCurrentGraphNode();
+
+    if (DriveGraph::get()->getNumberOfSuccessors(sector) > 1)
+        return;
+
+    // check if the player is going in the wrong direction
+    const DriveNode* node = DriveGraph::get()->getNode(sector);
+    Vec3 center_line = node->getUpperCenter() - node->getLowerCenter();
+    float angle_diff = kart->getVelocity().angle(center_line);
+
+    if (angle_diff > M_PI)
+        angle_diff -= 2*M_PI;
+    else if (angle_diff < -M_PI)
+        angle_diff += 2*M_PI;
+
+    // if the kart is going back way, i.e. if angle
+    // is too big(unless the kart has already finished the race).
+    // record how long this happens
+    if ((angle_diff > DEGREE_TO_RAD * 120.0f ||
+        angle_diff < -DEGREE_TO_RAD * 120.0f) &&
+        kart->getVelocityLC().getY() > 0.0f &&
+        !kart->hasFinishedRace())
+    {
+        ki.m_wrong_way_timer += dt;
+    }
+    else
+    {
+        if (!kart->hasFinishedRace() && !kart->getKartAnimation())
+        {
+            if (kart->getSpeed() < 5.0)
+                // stopping is also trolling
+                ki.m_wrong_way_timer += dt;
+            else if(kart->getSpeed() > 15.0)
+            {
+                // racing normally reduces timer
+                ki.m_wrong_way_timer -= dt;
+                if (ki.m_wrong_way_timer < 0)
+                    ki.m_wrong_way_timer = 0;
+            }
+        }
+    }
+
+    // If a kart is going wrong way for too long, take action
+    if (ki.m_warn_level == 0 && ki.m_wrong_way_timer > ServerConfig::m_troll_warning_time)
+    {   // warning
+        ki.m_warn_level = 1;
+        ki.m_wrong_way_timer = 0;
+    }
+    if (ki.m_warn_level == 1 && ki.m_wrong_way_timer > ServerConfig::m_troll_kick_time)
+    {   // kick
+        ki.m_warn_level = 2;
+    }
+}   // serverCheckForWrongDirection
+
+//-----------------------------------------------------------------------------
 void LinearWorld::setLastTriggeredCheckline(unsigned int kart_index, int index)
 {
     if (m_kart_info.size() == 0) return;

--- a/src/modes/linear_world.hpp
+++ b/src/modes/linear_world.hpp
@@ -104,6 +104,9 @@ private:
          *  direction so that a message can be displayed. */
         float       m_wrong_way_timer;
 
+        int         m_warn_level;
+        int         m_warn_issued;
+
         /** Initialises all fields. */
         KartInfo()  { reset(); }
         // --------------------------------------------------------------------
@@ -116,6 +119,8 @@ private:
             m_estimated_finish  = -1.0f;
             m_overall_distance  = 0.0f;
             m_wrong_way_timer   = 0.0f;
+            m_warn_level        = 0;
+            m_warn_issued       = 0;
         }   // reset
         // --------------------------------------------------------------------
         void saveCompleteState(BareNetworkString* bns);
@@ -192,6 +197,17 @@ public:
     {
         return m_kart_info[kart_index].m_overall_distance;
     }   // getOverallDistance
+    /** Returns the warn level
+     *  \param kart_index World kart id of the kart. */
+    int getWarnLevel(unsigned int kart_index)
+    {
+        if (m_kart_info[kart_index].m_warn_level > m_kart_info[kart_index].m_warn_issued)
+        {
+            m_kart_info[kart_index].m_warn_issued = m_kart_info[kart_index].m_warn_level;
+            return m_kart_info[kart_index].m_warn_level;
+        }
+        return 0;
+    }   // getWarnLevel
     // ------------------------------------------------------------------------
     /** Returns time for the fastest laps */
     float getFastestLap() const
@@ -236,6 +252,8 @@ public:
     void updateCheckLinesClient(const BareNetworkString& b);
     // ------------------------------------------------------------------------
     void handleServerCheckStructureCount(unsigned count);
+
+    void serverCheckForWrongDirection(unsigned int i, float dt);
 };   // LinearWorld
 
 #endif

--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -2427,14 +2427,20 @@ void ServerLobby::update(int ticks)
                         case 0: // fine
                             break;
                         case 1: // print WARNING
-                            {
-                                std::string msg = ServerConfig::m_troll_warn_msg;
-                                sendStringToPeer(msg, peer);
-                            }
+                        {
+                            std::string msg = ServerConfig::m_troll_warn_msg;
+                            sendStringToPeer(msg, peer);
+                            std::string player_name = StringUtils::wideToUtf8(peer->getPlayerProfiles()[0]->getName());
+                            Log::info("ServerLobby-AntiTroll", "Sent WARNING to %s", player_name.c_str());
                             break;
+                        }
                         default: // kick !!
+                        {
+                            std::string player_name = StringUtils::wideToUtf8(peer->getPlayerProfiles()[0]->getName());
+                            Log::info("ServerLobby-AntiTroll", "KICKING %s", player_name.c_str());
                             peer->kick();
                             break;
+                        }
                     }
                 }
             }

--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -245,6 +245,8 @@ ServerLobby::ServerLobby() : LobbyProtocol()
 
     m_fixed_lap = ServerConfig::m_fixed_lap_count;
 
+    m_troll_active = ServerConfig::m_troll_active;
+
     initAvailableModes();
 
     std::vector<int> all_k =

--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -2415,6 +2415,29 @@ void ServerLobby::update(int ticks)
                     StringUtils::wideToUtf8(rki.getPlayerName()).c_str(), sec);
                 peer->kick();
             }
+            if (m_troll_active && !peer->isAIPeer())
+            {
+                // for all human players
+                // if they troll, kick them
+                LinearWorld *lin_world = dynamic_cast<LinearWorld*>(w);
+                if (lin_world) {
+                    // check warn level for each player
+                    switch(lin_world->getWarnLevel(i))
+                    {
+                        case 0: // fine
+                            break;
+                        case 1: // print WARNING
+                            {
+                                std::string msg = ServerConfig::m_troll_warn_msg;
+                                sendStringToPeer(msg, peer);
+                            }
+                            break;
+                        default: // kick !!
+                            peer->kick();
+                            break;
+                    }
+                }
+            }
         }
     }
     if (w)
@@ -7673,6 +7696,25 @@ unmute_error:
                 }
                 sendStringToPeer(msg, peer);
             }
+            return;
+        }
+        if (argv[1] == "troll")
+        {
+            if (argv.size() == 2 || !(argv[2] == "0" || argv[2] == "1"))
+            {
+                msg = "Usage: /admin troll [0/1] - disable or enable anti troll system";
+                sendStringToPeer(msg, peer);
+                return;
+            }
+            if (argv[2] == "0")
+            {
+                m_troll_active = false;
+                msg = "Trolls can stay";
+            } else {
+                m_troll_active = true;
+                msg = "Trolls will be kicked";
+            }
+            sendStringToPeer(msg, peer);
             return;
         }
     }

--- a/src/network/protocols/server_lobby.hpp
+++ b/src/network/protocols/server_lobby.hpp
@@ -385,6 +385,9 @@ private:
     std::atomic<int> m_token_generation_tries;
 #endif
 
+    // config for troll system
+    bool  m_troll_active;
+
     // connection management
     void clientDisconnected(Event* event);
     void connectionRequested(Event* event);

--- a/src/network/server_config.hpp
+++ b/src/network/server_config.hpp
@@ -284,8 +284,16 @@ namespace ServerConfig
         "After this time (in sec) of backwards movement or stopping a warning is issued."));
 
     SERVER_CFG_PREFIX FloatServerConfigParam m_troll_kick_time
-        SERVER_CFG_DEFAULT(FloatServerConfigParam(9.0f, "troll-kick-time",
+        SERVER_CFG_DEFAULT(FloatServerConfigParam(10.0f, "troll-kick-time",
         "After this time (in sec) of backwards movement or stopping the player is kicked."));
+
+    SERVER_CFG_PREFIX FloatServerConfigParam m_troll_min_normal_speed
+        SERVER_CFG_DEFAULT(FloatServerConfigParam(12.0f, "troll-min-normal-speed",
+        "Minimum speed in correct direction to decrease wron_way timer."));
+
+    SERVER_CFG_PREFIX FloatServerConfigParam m_troll_max_stop_speed
+        SERVER_CFG_DEFAULT(FloatServerConfigParam(5.0f, "troll-max-stop-speed",
+        "A player going slower than this is considered stopping."));
 
     SERVER_CFG_PREFIX IntServerConfigParam m_min_start_game_players
         SERVER_CFG_DEFAULT(IntServerConfigParam(2, "min-start-game-players",

--- a/src/network/server_config.hpp
+++ b/src/network/server_config.hpp
@@ -270,6 +270,23 @@ namespace ServerConfig
         "If this value is set to true, players and the server must have "
         "at least one common official track."));
 
+    SERVER_CFG_PREFIX BoolServerConfigParam m_troll_active
+        SERVER_CFG_DEFAULT(BoolServerConfigParam(false, "use-anti-troll-system",
+        "If this value is set to true, warn and kick players who troll others."));
+
+    SERVER_CFG_PREFIX StringServerConfigParam m_troll_warn_msg
+        SERVER_CFG_DEFAULT(StringServerConfigParam("WARNING: You troll, you get kicked!",
+        "troll-warn-message",
+        "This message is shown as warning."));
+
+    SERVER_CFG_PREFIX FloatServerConfigParam m_troll_warning_time
+        SERVER_CFG_DEFAULT(FloatServerConfigParam(7.0f, "troll-warning-time",
+        "After this time (in sec) of backwards movement or stopping a warning is issued."));
+
+    SERVER_CFG_PREFIX FloatServerConfigParam m_troll_kick_time
+        SERVER_CFG_DEFAULT(FloatServerConfigParam(9.0f, "troll-kick-time",
+        "After this time (in sec) of backwards movement or stopping the player is kicked."));
+
     SERVER_CFG_PREFIX IntServerConfigParam m_min_start_game_players
         SERVER_CFG_DEFAULT(IntServerConfigParam(2, "min-start-game-players",
         "Only auto start kart selection when number of "


### PR DESCRIPTION
First attempt on a system that automatically kicks trolls.
That currently means, players who drive reverse for a longer time or who stop.
There is a warning and later the player gets kicked.
See README.MD for configuration.

This needs testing. :)

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
