### PR TITLE
Admin team wildcard search

### DIFF
--- a/src/network/stk_host.cpp
+++ b/src/network/stk_host.cpp
@@ -16,6 +16,8 @@
 //  along with this program; if not, write to the Free Software
 //  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
+#include <regex>
+
 #include "network/stk_host.hpp"
 
 #include "config/stk_config.hpp"
@@ -1488,7 +1490,7 @@ std::shared_ptr<STKPeer>
 
 //-----------------------------------------------------------------------------
 std::shared_ptr<STKPeer>
-    STKHost::findPeerBySubstring(const core::stringw& name, std::string& full_name) const
+    STKHost::findPeerByWildcard(const core::stringw& name_pattern, std::string& name_found) const
 {
     std::lock_guard<std::mutex> lock(m_peers_mutex);
     bool found = false;
@@ -1496,32 +1498,33 @@ std::shared_ptr<STKPeer>
     std::map<ENetPeer*, std::shared_ptr<STKPeer>>::const_iterator iter = m_peers.begin();
     std::map<ENetPeer*, std::shared_ptr<STKPeer>>::const_iterator end  = m_peers.end();
 
+    // change wildcard symbols to regex
+    std::string pat = StringUtils::wideToUtf8(name_pattern);
+    pat = std::regex_replace(pat, std::regex("\\?"), ".");
+    pat = std::regex_replace(pat, std::regex("\\*"), ".*");
+
+    std::regex regexString(pat, std::regex_constants::icase);
+
     for (; iter != end; iter++)
     {
         auto p = iter->second;
         for (auto& profile : p->getPlayerProfiles())
         {
-            if (profile->getName().find(name.c_str()) != -1)
+            if (std::regex_match(StringUtils::wideToUtf8(profile->getName()), regexString))
             {
-                if (profile->getName().size() == name.size()) {
-                    // found exact match
-                    // use that!
-                    full_name = StringUtils::wideToUtf8(name);
-                    return p;
-                } else if (found == true) {
+                if (found == true) {
                     // not unique
-                    // but keep going to not miss exact match
-                    ret = nullptr;
+                    return nullptr;
                 } else {
                     found = true;
-                    full_name = StringUtils::wideToUtf8(profile->getName());
+                    name_found = StringUtils::wideToUtf8(profile->getName());
                     ret = p;
                 }
             }
         }
     }
     return ret;
-}   // findPeerBySubstring
+}   // findPeerByWildcard
 
 //-----------------------------------------------------------------------------
 void STKHost::initClientNetwork(ENetEvent& event, Network* new_network)

--- a/src/network/stk_host.hpp
+++ b/src/network/stk_host.hpp
@@ -268,7 +268,7 @@ public:
     std::shared_ptr<STKPeer> findPeerByHostId(uint32_t id) const;
     // ------------------------------------------------------------------------
     std::shared_ptr<STKPeer> findPeerByName(const core::stringw& name) const;
-    std::shared_ptr<STKPeer> findPeerBySubstring(const core::stringw& name, std::string &full_name) const;
+    std::shared_ptr<STKPeer> findPeerByWildcard(const core::stringw& name_pattern, std::string &name_found) const;
     // ------------------------------------------------------------------------
     void sendPacketExcept(STKPeer* peer, NetworkString *data,
                           bool reliable = true);

--- a/src/network/stk_host.hpp
+++ b/src/network/stk_host.hpp
@@ -268,6 +268,7 @@ public:
     std::shared_ptr<STKPeer> findPeerByHostId(uint32_t id) const;
     // ------------------------------------------------------------------------
     std::shared_ptr<STKPeer> findPeerByName(const core::stringw& name) const;
+    std::shared_ptr<STKPeer> findPeerBySubstring(const core::stringw& name, std::string &full_name) const;
     // ------------------------------------------------------------------------
     void sendPacketExcept(STKPeer* peer, NetworkString *data,
                           bool reliable = true);


### PR DESCRIPTION
Use wildcard search for /admin team
You can use * and ? in the player name which is converted into a regular expression search internally. Since player names cannot contain any other characters that would needed to be escaped, it isn't done.
If no wildcard is used (no * or ?) a player's team color can be set even if the player is absent (as before).
If a wildcard is used and there is a unique match, the team color of that player is changed. If there is no match or more than one, an error message is printed.

Wildcard search is not case sensitive. Please let me know, if you want it to be.

Branch is now somehow misnamed... ;)
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
