### PR TITLE
Punish use of anchor (anvil) against teammates in Team GP

### DIFF
--- a/src/items/powerup.cpp
+++ b/src/items/powerup.cpp
@@ -38,6 +38,8 @@
 #include "utils/string_utils.hpp"
 #include "utils/log.hpp" //TODO: remove after debugging is done
 
+#include "network/protocols/server_lobby.hpp"
+
 //-----------------------------------------------------------------------------
 /** Constructor, stores the kart to which this powerup belongs.
  *  \param kart The kart to which this powerup belongs.
@@ -400,6 +402,11 @@ void Powerup::use()
             if(kart == m_kart) continue;
             if(kart->getPosition() == 1)
             {
+                // check if we are in team gp and hit a teammate and should punish the attacker
+                auto sl = LobbyProtocol::get<ServerLobby>();
+                if(sl && !kart->hasFinishedRace())
+                    sl->handleAnvilHit(m_kart->getWorldKartId(), kart->getWorldKartId());
+
                 kart->getAttachment()->set(Attachment::ATTACH_ANVIL,
                                            stk_config->
                                            time2Ticks(kp->getAnvilDuration()) );

--- a/src/network/protocols/server_lobby.cpp
+++ b/src/network/protocols/server_lobby.cpp
@@ -9393,3 +9393,61 @@ void ServerLobby::handleSwatterHit(unsigned int ownerID, unsigned int victimID,
             m_teammate_swatter_punish.push_back(owner);
     }
 }
+
+void ServerLobby::handleAnvilHit(unsigned int ownerID, unsigned int victimID)
+{
+    const std::string ownername = StringUtils::wideToUtf8(
+        RaceManager::get()->getKartInfo(ownerID).getPlayerName());
+    const int ownerTeam = m_team_for_player[ownername];
+    if (ownerTeam == 0)
+        return;
+
+    const std::string victimname = StringUtils::wideToUtf8(
+        RaceManager::get()->getKartInfo(victimID).getPlayerName());
+    const int victimTeam = m_team_for_player[victimname];
+    if (victimTeam != ownerTeam)
+        return;
+
+    AbstractKart *owner = World::getWorld()->getKart(ownerID);
+
+    // should we tell the world?
+    if (showTeamMateHits())
+    {
+        std::string msg = ServerConfig::m_teammate_hit_msg_prefix;
+        msg += ownername;
+        msg += " just gave an anchor to teammate ";
+        msg += victimname;
+        sendTeamMateHitMsg(msg);
+    }
+    if (useTeamMateHitMode())
+    {
+        if (owner->getAttachment()->getType() == Attachment::ATTACH_BOMB)
+        {
+            // make bomb explode
+            owner->getAttachment()->update(10000);
+        }
+        else
+        {
+            if (owner->isShielded())
+            {
+                // if owner is shielded, take away shield
+                // since the anvil will also destroy the shield of the victim
+                // we also punish this severely
+                owner->decreaseShieldTime();
+            }
+
+            // now give anvil to owner
+            int left_over_ticks = 0;
+            // if owner already has an anvil or a parachute, make new anvil last longer
+            if (owner->getAttachment()->getType() == Attachment::ATTACH_ANVIL
+                || owner->getAttachment()->getType() == Attachment::ATTACH_PARACHUTE)
+            {
+                left_over_ticks = owner->getAttachment()->getTicksLeft();
+            }
+            owner->getAttachment()->set(Attachment::ATTACH_ANVIL,
+                                        stk_config->time2Ticks(owner->getKartProperties()->getAnvilDuration()) + left_over_ticks);
+            // the powerup anvil is very strong, copy these values (from powerup.cpp)
+            owner->adjustSpeed(owner->getKartProperties()->getAnvilSpeedFactor() * 0.5f);
+        }
+    }
+}

--- a/src/network/protocols/server_lobby.hpp
+++ b/src/network/protocols/server_lobby.hpp
@@ -633,6 +633,8 @@ public:
 
     // handle swatters
     void handleSwatterHit(unsigned int ownerID, unsigned int victimID, bool success, bool has_hit_kart, uint16_t ticks_active);
+    // handle anvil
+    void handleAnvilHit(unsigned int ownerID, unsigned int victimID);
 
     void sendTeamMateHitMsg(std::string& s);
     bool showTeamMateHits() const    { return m_show_teammate_hits; }


### PR DESCRIPTION
I joined matahina's cake party team GP yesterday and was anchored by a teammate so often when leading...
So here I added the use of anchors against teammates to the punishment system.
I'm not sure it would have helped in that very moment, but yet... ;-)

Little side-note: I guess it would be possible, to make teammates immune against anchors, because the use of the anchor is initiated in the client, goes to the server, and if the server cuts it there, it should never reach any other client. So the original client might shortly see something going on, but that shouldn't disturb the player who just fired, and everybody else won't even notice something happened. I hope this makes sense. I'm not sure if this is a good thing to do, because it decreases the amount of attention one has to pay to not hurt teammates, but since it might be one of the few "immunity-things" actually possible, I just wanted to mention it.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
